### PR TITLE
Test buffers

### DIFF
--- a/Examples/Tests/SingleParticle/inputs
+++ b/Examples/Tests/SingleParticle/inputs
@@ -1,23 +1,37 @@
-max_step = 1
-amr.n_cell = 16 16
-amr.max_level = 0
+max_step = 200
+amr.n_cell = 128 64
+
+amr.max_level = 1
+
+# particles.deposit_on_main_grid = electron
+
+warpx.do_subcycling = 0
+warpx.do_pml = 0
+warpx.pml_ncell = 7
+warpx.n_current_deposition_buffer = 0
+warpx.n_field_gather_buffer = 8
+
 amr.blocking_factor = 8
-amr.max_grid_size = 8
+amr.max_grid_size = 256
 amr.plot_int = 1
 geometry.coord_sys   = 0
 geometry.is_periodic = 0 0
-geometry.prob_lo     = -8 -12
-geometry.prob_hi     =  8  12
-warpx.do_pml = 0
-algo.charge_deposition = standard
-algo.field_gathering = standard
+
+algo.maxwell_fdtd_solver = ckc
+
+geometry.prob_lo  =   0  0
+geometry.prob_hi  = 128 64
+warpx.fine_tag_lo =  32 32
+warpx.fine_tag_hi =  64 64
+
 warpx.cfl = 1.0
 
 particles.nspecies = 1
 particles.species_names = electron
+
 electron.charge = -q_e
-electron.mass = m_e
+electron.mass = 1.
 electron.injection_style = "SingleParticle"
-electron.single_particle_pos = 0.0   0.0 0.0
-electron.single_particle_vel = 1.e20 0.0 0.0  # gamma*beta
+electron.single_particle_pos = 1.5 0. 45.
+electron.single_particle_vel = 1.e20 0. 0.  # gamma*beta
 electron.single_particle_weight = 1.0

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -96,6 +96,7 @@ WarpX::EvolveEM (int numsteps)
         }
 
     int mlev = 0;
+
     if (Efield_cp [mlev][0].get()) NullifyMF(*Efield_cp [mlev][0], mlev, -1.e100, 1.e100,  1. );
     if (Efield_cp [mlev][1].get()) NullifyMF(*Efield_cp [mlev][1], mlev, -1.e100, 1.e100,  2. );
     if (Efield_cp [mlev][2].get()) NullifyMF(*Efield_cp [mlev][2], mlev, -1.e100, 1.e100,  3. );
@@ -105,6 +106,10 @@ WarpX::EvolveEM (int numsteps)
     if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  7. );
     if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  8. );
     if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  9. );
+    if (Efield_cax[mlev][0].get()) NullifyMF(*Efield_cax[mlev][0], mlev, -1.e100, 1.e100, 10. );
+    if (Efield_cax[mlev][1].get()) NullifyMF(*Efield_cax[mlev][1], mlev, -1.e100, 1.e100, 11. );
+    if (Efield_cax[mlev][2].get()) NullifyMF(*Efield_cax[mlev][2], mlev, -1.e100, 1.e100, 12. );
+
     if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  1. );
     if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  2. );
     if (Bfield_cp [mlev][2].get()) NullifyMF(*Bfield_cp [mlev][2], mlev, -1.e100, 1.e100,  3. );
@@ -117,7 +122,9 @@ WarpX::EvolveEM (int numsteps)
     if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_cax[mlev][0], mlev, -1.e100, 1.e100,  10. );
     if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_cax[mlev][1], mlev, -1.e100, 1.e100,  11. );
     if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_cax[mlev][2], mlev, -1.e100, 1.e100,  12. );
+
     mlev = 1;
+
     if (Efield_cp [mlev][0].get()) NullifyMF(*Efield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
     if (Efield_cp [mlev][1].get()) NullifyMF(*Efield_cp [mlev][1], mlev, -1.e100, 1.e100,  22. );
     if (Efield_cp [mlev][2].get()) NullifyMF(*Efield_cp [mlev][2], mlev, -1.e100, 1.e100,  23. );
@@ -127,6 +134,10 @@ WarpX::EvolveEM (int numsteps)
     if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
     if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
     if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
+    if (Efield_cax[mlev][0].get()) NullifyMF(*Efield_cax[mlev][0], mlev, -1.e100, 1.e100,  30. );
+    if (Efield_cax[mlev][1].get()) NullifyMF(*Efield_cax[mlev][1], mlev, -1.e100, 1.e100,  31. );
+    if (Efield_cax[mlev][2].get()) NullifyMF(*Efield_cax[mlev][2], mlev, -1.e100, 1.e100,  32. );
+
     if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
     if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  22. );
     if (Bfield_cp [mlev][2].get()) NullifyMF(*Bfield_cp [mlev][2], mlev, -1.e100, 1.e100,  23. );
@@ -136,9 +147,9 @@ WarpX::EvolveEM (int numsteps)
     if (Bfield_aux[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
     if (Bfield_aux[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
     if (Bfield_aux[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
-    if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  30. );
-    if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  31. );
-    if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  32. );
+    if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_cax[mlev][0], mlev, -1.e100, 1.e100,  30. );
+    if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_cax[mlev][1], mlev, -1.e100, 1.e100,  31. );
+    if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_cax[mlev][2], mlev, -1.e100, 1.e100,  32. );
 
         if (do_subcycling == 0 || finest_level == 0) {
             OneStep_nosub(cur_time);
@@ -288,7 +299,7 @@ WarpX::EvolveEM (int numsteps)
         FillBoundaryB();
         UpdateAuxilaryData();
         
-        /*
+/*
         for (int lev = 0; lev <= finest_level; ++lev) {
             mypc->FieldGather(lev,
                               *Efield_aux[lev][0],*Efield_aux[lev][1],
@@ -296,7 +307,7 @@ WarpX::EvolveEM (int numsteps)
                               *Bfield_aux[lev][0],*Bfield_aux[lev][1],
                               *Bfield_aux[lev][2]);
         }
-        */
+*/
 
         if (write_plot_file)
             WritePlotFile();
@@ -360,6 +371,7 @@ WarpX::OneStep_nosub (Real cur_time)
     FillBoundaryE();
     FillBoundaryB();
 #else
+/*
     EvolveF(0.5*dt[0], DtType::FirstHalf);
     FillBoundaryF();
     EvolveB(0.5*dt[0]); // We now have B^{n+1/2}
@@ -374,6 +386,7 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryE();
     }
     FillBoundaryB();
+*/
 
 #endif
 }

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -95,6 +95,51 @@ WarpX::EvolveEM (int numsteps)
 
         }
 
+    int mlev = 0;
+    if (Efield_cp [mlev][0].get()) NullifyMF(*Efield_cp [mlev][0], mlev, -1.e100, 1.e100,  1. );
+    if (Efield_cp [mlev][1].get()) NullifyMF(*Efield_cp [mlev][1], mlev, -1.e100, 1.e100,  2. );
+    if (Efield_cp [mlev][2].get()) NullifyMF(*Efield_cp [mlev][2], mlev, -1.e100, 1.e100,  3. );
+    if (Efield_fp [mlev][0].get()) NullifyMF(*Efield_fp [mlev][0], mlev, -1.e100, 1.e100,  4. );
+    if (Efield_fp [mlev][1].get()) NullifyMF(*Efield_fp [mlev][1], mlev, -1.e100, 1.e100,  5. );
+    if (Efield_fp [mlev][2].get()) NullifyMF(*Efield_fp [mlev][2], mlev, -1.e100, 1.e100,  6. );
+    if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  7. );
+    if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  8. );
+    if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  9. );
+    if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  1. );
+    if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  2. );
+    if (Bfield_cp [mlev][2].get()) NullifyMF(*Bfield_cp [mlev][2], mlev, -1.e100, 1.e100,  3. );
+    if (Bfield_fp [mlev][0].get()) NullifyMF(*Bfield_fp [mlev][0], mlev, -1.e100, 1.e100,  4. );
+    if (Bfield_fp [mlev][1].get()) NullifyMF(*Bfield_fp [mlev][1], mlev, -1.e100, 1.e100,  5. );
+    if (Bfield_fp [mlev][2].get()) NullifyMF(*Bfield_fp [mlev][2], mlev, -1.e100, 1.e100,  6. );
+    if (Bfield_aux[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  7. );
+    if (Bfield_aux[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  8. );
+    if (Bfield_aux[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  9. );
+    if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_cax[mlev][0], mlev, -1.e100, 1.e100,  10. );
+    if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_cax[mlev][1], mlev, -1.e100, 1.e100,  11. );
+    if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_cax[mlev][2], mlev, -1.e100, 1.e100,  12. );
+    mlev = 1;
+    if (Efield_cp [mlev][0].get()) NullifyMF(*Efield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
+    if (Efield_cp [mlev][1].get()) NullifyMF(*Efield_cp [mlev][1], mlev, -1.e100, 1.e100,  22. );
+    if (Efield_cp [mlev][2].get()) NullifyMF(*Efield_cp [mlev][2], mlev, -1.e100, 1.e100,  23. );
+    if (Efield_fp [mlev][0].get()) NullifyMF(*Efield_fp [mlev][0], mlev, -1.e100, 1.e100,  24. );
+    if (Efield_fp [mlev][1].get()) NullifyMF(*Efield_fp [mlev][1], mlev, -1.e100, 1.e100,  25. );
+    if (Efield_fp [mlev][2].get()) NullifyMF(*Efield_fp [mlev][2], mlev, -1.e100, 1.e100,  26. );
+    if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
+    if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
+    if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
+    if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
+    if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  22. );
+    if (Bfield_cp [mlev][2].get()) NullifyMF(*Bfield_cp [mlev][2], mlev, -1.e100, 1.e100,  23. );
+    if (Bfield_fp [mlev][0].get()) NullifyMF(*Bfield_fp [mlev][0], mlev, -1.e100, 1.e100,  24. );
+    if (Bfield_fp [mlev][1].get()) NullifyMF(*Bfield_fp [mlev][1], mlev, -1.e100, 1.e100,  25. );
+    if (Bfield_fp [mlev][2].get()) NullifyMF(*Bfield_fp [mlev][2], mlev, -1.e100, 1.e100,  26. );
+    if (Bfield_aux[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
+    if (Bfield_aux[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
+    if (Bfield_aux[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
+    if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  30. );
+    if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  31. );
+    if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  32. );
+
         if (do_subcycling == 0 || finest_level == 0) {
             OneStep_nosub(cur_time);
         } else if (do_subcycling == 1 && finest_level == 1) {
@@ -189,11 +234,13 @@ WarpX::EvolveEM (int numsteps)
             FillBoundaryB();
             UpdateAuxilaryData();
 
+            /*
             for (int lev = 0; lev <= finest_level; ++lev) {
                 mypc->FieldGather(lev,
                                   *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
                                   *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
             }
+            */
 
             last_plot_file_step = step+1;
             last_insitu_step = step+1;
@@ -240,7 +287,8 @@ WarpX::EvolveEM (int numsteps)
         FillBoundaryE();
         FillBoundaryB();
         UpdateAuxilaryData();
-
+        
+        /*
         for (int lev = 0; lev <= finest_level; ++lev) {
             mypc->FieldGather(lev,
                               *Efield_aux[lev][0],*Efield_aux[lev][1],
@@ -248,6 +296,7 @@ WarpX::EvolveEM (int numsteps)
                               *Bfield_aux[lev][0],*Bfield_aux[lev][1],
                               *Bfield_aux[lev][2]);
         }
+        */
 
         if (write_plot_file)
             WritePlotFile();
@@ -642,12 +691,12 @@ WarpX::applyMirrors(Real time){
             MultiFab& By = *Bfield_fp[lev][1].get();
             MultiFab& Bz = *Bfield_fp[lev][2].get();
             // Set each field to zero between z_min and z_max
-            NullifyMF(Ex, lev, z_min, z_max);
-            NullifyMF(Ey, lev, z_min, z_max);
-            NullifyMF(Ez, lev, z_min, z_max);
-            NullifyMF(Bx, lev, z_min, z_max);
-            NullifyMF(By, lev, z_min, z_max);
-            NullifyMF(Bz, lev, z_min, z_max);
+            NullifyMF(Ex, lev, z_min, z_max, 0.);
+            NullifyMF(Ey, lev, z_min, z_max, 0.);
+            NullifyMF(Ez, lev, z_min, z_max, 0.);
+            NullifyMF(Bx, lev, z_min, z_max, 0.);
+            NullifyMF(By, lev, z_min, z_max, 0.);
+            NullifyMF(Bz, lev, z_min, z_max, 0.);
             if (lev>0){
                 // Get coarse patch field MultiFabs
                 MultiFab& cEx = *Efield_cp[lev][0].get();
@@ -657,12 +706,12 @@ WarpX::applyMirrors(Real time){
                 MultiFab& cBy = *Bfield_cp[lev][1].get();
                 MultiFab& cBz = *Bfield_cp[lev][2].get();
                 // Set each field to zero between z_min and z_max
-                NullifyMF(cEx, lev, z_min, z_max);
-                NullifyMF(cEy, lev, z_min, z_max);
-                NullifyMF(cEz, lev, z_min, z_max);
-                NullifyMF(cBx, lev, z_min, z_max);
-                NullifyMF(cBy, lev, z_min, z_max);
-                NullifyMF(cBz, lev, z_min, z_max);
+                NullifyMF(cEx, lev, z_min, z_max, 0.);
+                NullifyMF(cEy, lev, z_min, z_max, 0.);
+                NullifyMF(cEz, lev, z_min, z_max, 0.);
+                NullifyMF(cBx, lev, z_min, z_max, 0.);
+                NullifyMF(cBy, lev, z_min, z_max, 0.);
+                NullifyMF(cBz, lev, z_min, z_max, 0.);
             }
         }
     }

--- a/Source/Evolve/WarpXEvolveEM.cpp
+++ b/Source/Evolve/WarpXEvolveEM.cpp
@@ -91,9 +91,6 @@ WarpX::EvolveEM (int numsteps)
             // Particles have p^{n-1/2} and x^{n}.
             FillBoundaryE();
             FillBoundaryB();
-            UpdateAuxilaryData();
-
-        }
 
     int mlev = 0;
 
@@ -103,12 +100,14 @@ WarpX::EvolveEM (int numsteps)
     if (Efield_fp [mlev][0].get()) NullifyMF(*Efield_fp [mlev][0], mlev, -1.e100, 1.e100,  4. );
     if (Efield_fp [mlev][1].get()) NullifyMF(*Efield_fp [mlev][1], mlev, -1.e100, 1.e100,  5. );
     if (Efield_fp [mlev][2].get()) NullifyMF(*Efield_fp [mlev][2], mlev, -1.e100, 1.e100,  6. );
+/*
     if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  7. );
     if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  8. );
     if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  9. );
     if (Efield_cax[mlev][0].get()) NullifyMF(*Efield_cax[mlev][0], mlev, -1.e100, 1.e100, 10. );
     if (Efield_cax[mlev][1].get()) NullifyMF(*Efield_cax[mlev][1], mlev, -1.e100, 1.e100, 11. );
     if (Efield_cax[mlev][2].get()) NullifyMF(*Efield_cax[mlev][2], mlev, -1.e100, 1.e100, 12. );
+*/
 
     if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  1. );
     if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  2. );
@@ -116,13 +115,14 @@ WarpX::EvolveEM (int numsteps)
     if (Bfield_fp [mlev][0].get()) NullifyMF(*Bfield_fp [mlev][0], mlev, -1.e100, 1.e100,  4. );
     if (Bfield_fp [mlev][1].get()) NullifyMF(*Bfield_fp [mlev][1], mlev, -1.e100, 1.e100,  5. );
     if (Bfield_fp [mlev][2].get()) NullifyMF(*Bfield_fp [mlev][2], mlev, -1.e100, 1.e100,  6. );
+/*
     if (Bfield_aux[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  7. );
     if (Bfield_aux[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  8. );
     if (Bfield_aux[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  9. );
     if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_cax[mlev][0], mlev, -1.e100, 1.e100,  10. );
     if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_cax[mlev][1], mlev, -1.e100, 1.e100,  11. );
     if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_cax[mlev][2], mlev, -1.e100, 1.e100,  12. );
-
+*/
     mlev = 1;
 
     if (Efield_cp [mlev][0].get()) NullifyMF(*Efield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
@@ -131,12 +131,14 @@ WarpX::EvolveEM (int numsteps)
     if (Efield_fp [mlev][0].get()) NullifyMF(*Efield_fp [mlev][0], mlev, -1.e100, 1.e100,  24. );
     if (Efield_fp [mlev][1].get()) NullifyMF(*Efield_fp [mlev][1], mlev, -1.e100, 1.e100,  25. );
     if (Efield_fp [mlev][2].get()) NullifyMF(*Efield_fp [mlev][2], mlev, -1.e100, 1.e100,  26. );
+/*
     if (Efield_aux[mlev][0].get()) NullifyMF(*Efield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
     if (Efield_aux[mlev][1].get()) NullifyMF(*Efield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
     if (Efield_aux[mlev][2].get()) NullifyMF(*Efield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
     if (Efield_cax[mlev][0].get()) NullifyMF(*Efield_cax[mlev][0], mlev, -1.e100, 1.e100,  30. );
     if (Efield_cax[mlev][1].get()) NullifyMF(*Efield_cax[mlev][1], mlev, -1.e100, 1.e100,  31. );
     if (Efield_cax[mlev][2].get()) NullifyMF(*Efield_cax[mlev][2], mlev, -1.e100, 1.e100,  32. );
+*/
 
     if (Bfield_cp [mlev][0].get()) NullifyMF(*Bfield_cp [mlev][0], mlev, -1.e100, 1.e100,  21. );
     if (Bfield_cp [mlev][1].get()) NullifyMF(*Bfield_cp [mlev][1], mlev, -1.e100, 1.e100,  22. );
@@ -144,12 +146,19 @@ WarpX::EvolveEM (int numsteps)
     if (Bfield_fp [mlev][0].get()) NullifyMF(*Bfield_fp [mlev][0], mlev, -1.e100, 1.e100,  24. );
     if (Bfield_fp [mlev][1].get()) NullifyMF(*Bfield_fp [mlev][1], mlev, -1.e100, 1.e100,  25. );
     if (Bfield_fp [mlev][2].get()) NullifyMF(*Bfield_fp [mlev][2], mlev, -1.e100, 1.e100,  26. );
+/*
     if (Bfield_aux[mlev][0].get()) NullifyMF(*Bfield_aux[mlev][0], mlev, -1.e100, 1.e100,  27. );
     if (Bfield_aux[mlev][1].get()) NullifyMF(*Bfield_aux[mlev][1], mlev, -1.e100, 1.e100,  28. );
     if (Bfield_aux[mlev][2].get()) NullifyMF(*Bfield_aux[mlev][2], mlev, -1.e100, 1.e100,  29. );
     if (Bfield_cax[mlev][0].get()) NullifyMF(*Bfield_cax[mlev][0], mlev, -1.e100, 1.e100,  30. );
     if (Bfield_cax[mlev][1].get()) NullifyMF(*Bfield_cax[mlev][1], mlev, -1.e100, 1.e100,  31. );
     if (Bfield_cax[mlev][2].get()) NullifyMF(*Bfield_cax[mlev][2], mlev, -1.e100, 1.e100,  32. );
+*/
+
+            UpdateAuxilaryData();
+
+        }
+
 
         if (do_subcycling == 0 || finest_level == 0) {
             OneStep_nosub(cur_time);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -8,6 +8,7 @@
 #include <WarpXWrappers.h>
 #include <IonizationEnergiesTable.H>
 #include <FieldGather.H>
+#include <WarpXUtil.H>
 
 #include <WarpXAlgorithmSelection.H>
 
@@ -1324,7 +1325,6 @@ PhysicalParticleContainer::Evolve (int lev,
                                    np_current, np-np_current, thread_num,
                                    lev, lev-1, dt);
                 }
-
 
                 //
                 // copy particle data back

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -8,4 +8,4 @@ void ReadBoostedFrameParameters(amrex::Real& gamma_boost, amrex::Real& beta_boos
 void ConvertLabParamsToBoost();
 
 void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, 
-               amrex::Real zmax);
+               amrex::Real zmax, amrex::Real val);

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -116,16 +116,17 @@ void ConvertLabParamsToBoost()
 /* \brief Function that sets the value of MultiFab MF to zero for z between 
  * zmin and zmax.
  */
-void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax){
+void NullifyMF(MultiFab& mf, int lev, Real zmin, Real zmax, Real val){
     BL_PROFILE("WarpX::NullifyMF()");
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for(amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
-        const amrex::Box& bx = mfi.tilebox();
+    for(MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi){
+        // const Box& bx = mfi.tilebox();
+        const Box& bx = mfi.growntilebox();
         // Get box lower and upper physical z bound, and dz
-        const amrex::Real zmin_box = WarpX::LowerCorner(bx, lev)[2];
-        const amrex::Real zmax_box = WarpX::UpperCorner(bx, lev)[2];
+        const Real zmin_box = WarpX::LowerCorner(bx, lev)[2];
+        const Real zmax_box = WarpX::UpperCorner(bx, lev)[2];
         amrex::Real dz  = WarpX::CellSize(lev)[2];
         // Get box lower index in the z direction
 #if (AMREX_SPACEDIM==3)
@@ -145,7 +146,7 @@ void NullifyMF(amrex::MultiFab& mf, int lev, amrex::Real zmin, amrex::Real zmax)
                     const Real z_gridpoint = zmin_box+(j-lo_ind)*dz;
 #endif 
                     if ( (z_gridpoint >= zmin) && (z_gridpoint < zmax) ) {
-                        arr(i,j,k) = 0.;
+                        arr(i,j,k) = val;
                     };
                 }
             );


### PR DESCRIPTION
You can run the example on this branch and visualize the results with (I copy that in a Jupiter notebook)

```py
# Import statements
import yt ; yt.funcs.mylog.setLevel(50)
import numpy as np
import scipy.constants as scc
import matplotlib.pyplot as plt
%matplotlib notebook

ds = yt.load( './diags/plotfiles/plt00068' ) # Create a dataset object
species = 'electron'
sl = yt.SlicePlot(ds, 2, 'Ex', aspect=1) # Create a sliceplot object
sl.annotate_particles(width=(10.e-6, 'm'), p_size=5, ptype=species, col='black')
sl.annotate_grids() # Show grids
sl.show() # Show the plot
ad = ds.all_data()
x = ad[species, 'particle_position_x'].v
ex = ad[species, 'particle_Ex'].v
ey = ad[species, 'particle_Ey'].v
ez = ad[species, 'particle_Ez'].v
bx = ad[species, 'particle_Bx'].v
by = ad[species, 'particle_By'].v
bz = ad[species, 'particle_Bz'].v
print(' x = ' + str( x))
print('ex = ' + str(ex))
print('ey = ' + str(ey))
print('ez = ' + str(ez))
print('bx = ' + str(bx))
print('by = ' + str(by))
print('bz = ' + str(bz))
```
For particle on level 1:
If gathering from level 1 (i.e., not from "main grid"), we gather from `aux`
```
aux [ lev=1 ] = fp [ lev=1 ] - cp [ lev=1 ] + aux[ lev=0 ]
```
If gathering from level 0 (i.e., from "main grid"), we gather from `cax`
```
cax [ lev=1 ] = aux[ lev=0 ] = fp [ lev=0 ]
```